### PR TITLE
Added support for JOINs

### DIFF
--- a/EBrown.SqlDsl/Script.fsx
+++ b/EBrown.SqlDsl/Script.fsx
@@ -16,7 +16,12 @@ let query = {
             Limit = None
             Group = None
             Sort = None
-            Include = [] }
+            Include = 
+                [{
+                    Name = Alias (Name (Raw "Customers"), "Customer")
+                    Type = Inner
+                    On = [{Filter.Name = Qualified("Customer", "Id"); Clause = Equal (Qualified ("Order", "CustomerId"));}]
+                }]}
     Table = Raw "OrderItems" }
 let queryStr = query |> Generation.query
 printfn "%s" queryStr

--- a/EBrown.SqlDsl/Types.fs
+++ b/EBrown.SqlDsl/Types.fs
@@ -1,4 +1,5 @@
 ﻿module EBrown.SqlDsl.Types
+
 type VarSize = | Size of int | Max
 type XmlType = | Content | Document
 type TimeScale = | S0 | S1 | S2 | S3 | S4 | S5 | S6 | S7
@@ -27,8 +28,8 @@ and AliasNameFunc = | Qualified of string * string | Name of AliasName | Func of
 type Table = { Name : string; KeyColumns : SqlColumn array; Columns : SqlColumn array; Relationships : Relationship list }
 type SelectWhat = | Everything | Columns of AliasNameFunc array
 type SortDirection = | Ascending of string | Descending of string
-type FilterClause = | Equal of string | NotEqual of string | Between of string * string
-type Filter = { Name : string; Clause : FilterClause }
+type FilterClause = | Equal of AliasNameFunc | NotEqual of AliasNameFunc | Between of AliasNameFunc * AliasNameFunc
+type Filter = { Name : AliasNameFunc; Clause : FilterClause }
 type JoinType = | Left | Right | Outer | Inner
 type Join = { Type : JoinType; Name : AliasName; On : Filter list }
 type SelectQuery = { What : SelectWhat; Limit : int option; Group : string array option; Sort : SortDirection array option; Include : Join list }


### PR DESCRIPTION
Generates following output
> SELECT [OrderId], [PoNumber] AS [PurchaseOrderNumber], [Customer] AS [CustomerName] FROM [OrderItems] INNER JOIN [Customers] AS [Customer] ON [Customer].[Id] = [Order].[CustomerId]

Also allows for multiple Joins to be specified within one query by later joining the list using joinStrings separating each generated Join with a whitespace.